### PR TITLE
Fix misplaced comments in spawning docs

### DIFF
--- a/content/docs/futures/spawning.md
+++ b/content/docs/futures/spawning.md
@@ -300,14 +300,12 @@ tokio::run(lazy(|| {
             // Each spawned task will have a clone of the sender handle.
             let tx = tx.clone();
 
-            // In this example, "hello world" will be written to the
-            // socket followed by the socket being closed.
             io::read_to_end(socket, vec![])
-                // Drop the socket
                 .and_then(move |(_, buf)| {
                     tx.send(buf.len())
                         .map_err(|_| io::ErrorKind::Other.into())
                 })
+                // Drop the socket
                 .map(|_| ())
                 // Write any error to STDOUT
                 .map_err(|e| println!("socket error = {:?}", e))


### PR DESCRIPTION
In the background processing code example there seem to be 2 misplaced comments.
I removed the one about writing to the socket since it doesn't make sense in this context and moved the drop comment right before `.map(|_| ())` where it should be, as far as I can tell.
Let me know if the first comment should be replaced instead.